### PR TITLE
added _authenticate_jwt(), get_secret() and user-defined cred provider options for authn functions.

### DIFF
--- a/agent_guard_core/credentials/conjur_secrets_provider.py
+++ b/agent_guard_core/credentials/conjur_secrets_provider.py
@@ -99,15 +99,9 @@ class ConjurSecretsProvider(BaseSecretsProvider):
             bool: True if the authentication succeeded, False if it failed.
         """
 
-        if self._ext_authn_cred_provider is not None:
-            self.logger.debug(
-                "ConjurSecretsProvider:_authenticate_aws_iam(): Calling external credential provider function..."
-            )
-            credentials = self._ext_authn_cred_provider()
-        else:
-            session = boto3.Session()
-            credentials = session.get_credentials()
-            credentials = credentials.get_frozen_credentials()
+        session = boto3.Session()
+        credentials = session.get_credentials()
+        credentials = credentials.get_frozen_credentials()
         if credentials is None:
             self.logger.error(
                 "ConjurSecretsProvider:_authenticate_aws_iam(): Error getting AWS IAM credentials."

--- a/agent_guard_core/credentials/conjur_secrets_provider.py
+++ b/agent_guard_core/credentials/conjur_secrets_provider.py
@@ -12,6 +12,7 @@ import requests
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from dotenv import load_dotenv
+from http import HTTPStatus
 
 from agent_guard_core.credentials.secrets_provider import BaseSecretsProvider, SecretProviderException
 
@@ -26,10 +27,6 @@ DEFAULT_SECRET_ID = "agentic_env_vars"
 DEFAULT_CONJUR_ACCOUNT = "conjur"
 
 HTTP_TIMEOUT_SECS = 2.0
-HTTP_SUCCESS = 200
-HTTP_CREATED = 201
-HTTP_NOTFOUND_OR_EMPTY = 404
-
 
 class ConjurSecretsProvider(BaseSecretsProvider):
     """
@@ -127,7 +124,7 @@ class ConjurSecretsProvider(BaseSecretsProvider):
             headers=headers,
             timeout=HTTP_TIMEOUT_SECS,
         )
-        if response.status_code == HTTP_SUCCESS:
+        if response.status_code == HTTPStatus.OK:
             self._access_token = response.text
             return True
         return False
@@ -169,7 +166,7 @@ class ConjurSecretsProvider(BaseSecretsProvider):
             headers=headers,
             timeout=HTTP_TIMEOUT_SECS,
         )
-        if response.status_code == HTTP_SUCCESS:
+        if response.status_code == HTTPStatus.OK:
             self._access_token = response.text
             return True
         return False
@@ -222,7 +219,7 @@ class ConjurSecretsProvider(BaseSecretsProvider):
             headers=headers,
             timeout=HTTP_TIMEOUT_SECS,
         )
-        if response.status_code == HTTP_SUCCESS:
+        if response.status_code == HTTPStatus.OK:
             self._access_token = response.text
             return True
 
@@ -289,11 +286,11 @@ class ConjurSecretsProvider(BaseSecretsProvider):
                 headers=self._get_conjur_headers(),
                 timeout=HTTP_TIMEOUT_SECS,
             )
-            if response.status_code == HTTP_NOTFOUND_OR_EMPTY:
+            if response.status_code == HTTPStatus.NOT_FOUND:
                 self.logger.error("Secret %s: not found or has empty value.",
                                   secret_id)
                 return None
-            if response.status_code != HTTP_SUCCESS:
+            if response.status_code != HTTPStatus.OK:
                 self.logger.error("get_secret(): secret retrieval error: %s",
                                   response.text)
                 raise SecretProviderException(response.text)
@@ -319,11 +316,11 @@ class ConjurSecretsProvider(BaseSecretsProvider):
                 headers=self._get_conjur_headers(),
                 timeout=HTTP_TIMEOUT_SECS,
             )
-            if response.status_code == HTTP_NOTFOUND_OR_EMPTY:
+            if response.status_code == HTTPStatus.NOT_FOUND:
                 self.logger.error("Secret %s: not found or has empty value.",
                                   self._secret_name)
                 return {}
-            if response.status_code != HTTP_SUCCESS:
+            if response.status_code != HTTPStatus.OK:
                 self.logger.error("get: secret retrieval error: %s",
                                   response.text)
                 raise SecretProviderException(response.text)
@@ -357,7 +354,7 @@ class ConjurSecretsProvider(BaseSecretsProvider):
                 headers=self._get_conjur_headers(),
                 timeout=HTTP_TIMEOUT_SECS,
             )
-            if response.status_code != HTTP_CREATED:
+            if response.status_code != HTTPStatus.CREATED:
                 self.logger.error("Error creating secret: %s", response.text)
                 raise SecretProviderException(
                     f"Error storing secret: {response.text}")
@@ -369,7 +366,7 @@ class ConjurSecretsProvider(BaseSecretsProvider):
                 headers=self._get_conjur_headers(),
                 timeout=HTTP_TIMEOUT_SECS,
             )
-            if response.status_code != HTTP_CREATED:
+            if response.status_code != HTTPStatus.CREATED:
                 self.logger.error("Error storing secret: %s", response.text)
                 raise SecretProviderException(
                     f"Error storing secret: {response.text}")


### PR DESCRIPTION
### Desired Outcome

Need to support JWT authentication to Conjur, used for authenticating workloads in K8s, GitLab, GitHub actions, etc.
Need to support individual secrets retrieval from Conjur (k/v retrieval of non-json values).
Need to provide flexible way of providing authn credentials to authenticators but allow for use of env vars as defaults.

### Implemented Changes

- Tweaked __init__ to accept optional reference to external cred provider function and  moved gets of env vars to functions where they are used, to reduce number of instance vars.
- Added _authenticate_jwt() with call to optional external provider.
- Modified _authenticate_aws() and _authenticate_api_key() calls to optional external cred provider functions.
- Added get_secret() to take Conjur secret ID as arg and return value of secret.
- Tweaked misc code as suggested by pylint.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- Changelog?

#### Test coverage

- JWT & API key authentication methods have been tested.
- AWS authentication needs to be tested.

#### Documentation

- Docs to be updated after code review.

#### Behavior

- [ ] These changes are part of a larger initiative that will be reviewed later, or

#### Security

- [ ] These changes are part of a larger initiative with a separate security review, or

