### PR TITLE
added _authenticate_jwt(), get_secret() and user-defined cred provider options for authn functions. (#31)

### DIFF
--- a/agent_guard_core/cli.md
+++ b/agent_guard_core/cli.md
@@ -1,0 +1,61 @@
+# Agent Guard CLI
+
+The Agent Guard CLI provides commands to configure and manage secret providers and related options for Agent Guard.
+
+## Usage
+
+```sh
+agent-guard [COMMAND] [OPTIONS]
+```
+
+## Commands
+
+### configure
+
+Group of commands to manage Agent Guard configuration.
+
+#### set
+
+Set the secret provider and related Conjur options.
+
+**Options:**
+- `--provider [PROVIDER]`  
+  The secret provider to store and retrieve secrets.  
+  Choices: `AWS_SECRETS_MANAGER_PROVIDER`, `FILE_SECRET_PROVIDER`, `CONJUR_SECRET_PROVIDER`  
+  Default: `FILE_SECRET_PROVIDER`
+
+- `--conjur_authn_login [LOGIN]`  
+  (Optional) Conjur authentication login (workload ID).
+
+- `--conjur_authn_api_key [API_KEY]`  
+  (Optional) API Key to authenticate to Conjur Cloud.
+
+- `--conjur_appliance_url [URL]`  
+  (Optional) Endpoint URL of Conjur Cloud.
+
+**Example:**
+```sh
+agent-guard configure set --provider CONJUR_SECRET_PROVIDER --conjur_authn_login my-app --conjur_authn_api_key my-key --conjur_appliance_url https://conjur.example.com
+```
+
+#### list
+
+List all configuration parameters and their values.
+
+**Example:**
+```sh
+agent-guard configure list
+```
+
+## Help
+
+For help on any command, use the `--help` flag:
+
+```sh
+agent-guard configure set --help
+```
+
+---
+
+**Note:**  
+The CLI stores configuration in a file under your home directory: `~/.agent_guard/config.env`

--- a/agent_guard_core/cli.py
+++ b/agent_guard_core/cli.py
@@ -1,0 +1,86 @@
+import click
+
+from agent_guard_core.config.config_manager import ConfigManager, ConfigurationOptions, SecretProviderOptions
+
+# Retrieve the list of supported secret providers and the default provider.
+provider_list = SecretProviderOptions.get_secret_provider_keys()
+default_provider = SecretProviderOptions.get_default_secret_provider()
+
+
+@click.group()
+def cli():
+    """
+    Entry point for the Agent Guard CLI.
+    """
+
+
+@click.group()
+def configure():
+    """
+    Commands to manage Agent Guard configuration.
+    """
+
+
+@configure.command()
+@click.option(
+    '--provider',
+    default=default_provider,
+    prompt=True,
+    type=click.Choice(provider_list),
+    help=('The secret provider to store and retrieve secrets.\n'
+          f'Choose from: {provider_list}'),
+)
+@click.option('--conjur_authn_login',
+              required=False,
+              help="Conjur authentication login (workload ID).")
+@click.option('--conjur_authn_api_key',
+              required=False,
+              help="API Key to authenticate to Conjur Cloud.")
+@click.option('--conjur_appliance_url',
+              required=False,
+              help="Endpoint URL of Conjur Cloud.")
+def set(provider, conjur_authn_login, conjur_authn_api_key,
+        conjur_appliance_url):
+    """
+    Set the secret provider and related Conjur options in the Agent Guard configuration.
+
+    You can specify the provider and, if using Conjur, provide additional authentication details.
+    """
+    config_manager = ConfigManager()
+    config_manager.set_config_value(
+        key=ConfigurationOptions.SECRET_PROVIDER.name, value=provider)
+    if conjur_authn_login:
+        config_manager.set_config_value(
+            key=ConfigurationOptions.CONJUR_AUTHN_LOGIN.name,
+            value=conjur_authn_login)
+    if conjur_authn_api_key:
+        config_manager.set_config_value(
+            key=ConfigurationOptions.CONJUR_AUTHN_API_KEY.name,
+            value=conjur_authn_api_key)
+    if conjur_appliance_url:
+        config_manager.set_config_value(
+            key=ConfigurationOptions.CONJUR_APPLIANCE_URL.name,
+            value=conjur_appliance_url)
+
+
+@configure.command('list')
+def list_params():
+    """
+    List all configuration parameters and their values for Agent Guard.
+
+    Displays the current configuration as key-value pairs.
+    """
+    config_manager = ConfigManager()
+    config = config_manager.get_config()
+    click.echo("Agent Guard Configuration:")
+    if config:
+        for k, v in config.items():
+            click.echo(f"  {k}={v}")
+    else:
+        click.echo("  No configuration found.")
+
+
+cli.add_command(configure)
+
+if __name__ == '__main__':
+    cli()

--- a/agent_guard_core/config/config_manager.py
+++ b/agent_guard_core/config/config_manager.py
@@ -1,0 +1,69 @@
+from enum import Enum
+from pathlib import Path
+
+from agent_guard_core.credentials.file_secrets_provider import FileSecretsProvider
+
+
+class ConfigurationOptions(Enum):
+    """
+    Enum for configuration keys used by Agent Guard.
+    """
+    SECRET_PROVIDER = "The secret provider that Agent Guard supports"
+    CONJUR_AUTHN_LOGIN = "The ID of the workload that authenticates to Conjur"
+    CONJUR_APPLIANCE_URL = "The endpoint URL of Conjur Cloud"
+    CONJUR_AUTHN_API_KEY = "The API Key to authenticate in the cloud"
+
+
+class SecretProviderOptions(Enum):
+    """
+    Enum for supported secret providers.
+    """
+    AWS_SECRETS_MANAGER_PROVIDER = "AWS Secrets Manager"
+    FILE_SECRET_PROVIDER = "local.env file"
+    CONJUR_SECRET_PROVIDER = "CyberArk Conjur Cloud"
+
+    @classmethod
+    def get_secret_provider_keys(cls):
+        """
+        Return a list of all secret provider keys (enum names).
+        """
+        return [member.name for member in cls]
+
+    @classmethod
+    def get_default_secret_provider(cls):
+        """
+        Return the default secret provider key.
+        """
+        return cls.FILE_SECRET_PROVIDER.name
+
+
+class ConfigManager:
+    """
+    Manages Agent Guard configuration using a file-based secrets provider.
+    """
+
+    def __init__(self):
+        self._config_file_path = Path.joinpath(Path.home(), '.agent_guard',
+                                               'config.env')
+        self._config_provider = FileSecretsProvider(
+            namespace=self._config_file_path)
+        self._config_dictionary = self._config_provider.get_secret_dictionary()
+
+    def get_config(self):
+        """
+        Get the current configuration as a dictionary.
+        """
+        return self._config_dictionary
+
+    def set_config_value(self, key, value):
+        """
+        Set a specific key to a value in the config file.
+        """
+        self._config_dictionary[key] = value
+        self._config_provider.store_secret_dictionary(self._config_dictionary)
+
+    def get_config_value(self, key):
+        """
+        Get a specific value for a key from the config file.
+        """
+        return self._config_dictionary.get(key)

--- a/agent_guard_core/credentials/conjur_secrets_provider.py
+++ b/agent_guard_core/credentials/conjur_secrets_provider.py
@@ -5,6 +5,7 @@ import json
 import os
 import urllib.parse
 from datetime import datetime, timedelta
+from http import HTTPStatus
 from typing import Dict, Optional
 
 import boto3
@@ -12,7 +13,6 @@ import requests
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from dotenv import load_dotenv
-from http import HTTPStatus
 
 from agent_guard_core.credentials.secrets_provider import BaseSecretsProvider, SecretProviderException
 
@@ -27,6 +27,7 @@ DEFAULT_SECRET_ID = "agentic_env_vars"
 DEFAULT_CONJUR_ACCOUNT = "conjur"
 
 HTTP_TIMEOUT_SECS = 2.0
+
 
 class ConjurSecretsProvider(BaseSecretsProvider):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[project.scripts]
+agent-guard = "agent_guard_core.cli:cli"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -1,0 +1,49 @@
+import pytest
+from click.testing import CliRunner
+
+from agent_guard_core.cli import cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_configure_set_and_list(monkeypatch, tmp_path, runner):
+    # Patch ConfigManager to use a dummy config dictionary in memory
+    from agent_guard_core import cli as cli_module
+
+    class DummyConfigManager:
+
+        def __init__(self):
+            self._config = {}
+
+        def set_config_value(self, key, value):
+            self._config[key] = value
+
+        def get_config(self):
+            return self._config
+
+    monkeypatch.setattr(cli_module, "ConfigManager", DummyConfigManager)
+
+    # Set a value
+    result = runner.invoke(
+        cli, ['configure', 'set', '--provider', 'FILE_SECRET_PROVIDER'])
+    assert result.exit_code == 0
+
+    # Set another value
+    result = runner.invoke(cli, [
+        'configure', 'set', '--provider', 'CONJUR_SECRET_PROVIDER',
+        '--conjur_authn_login', 'user1'
+    ])
+    assert result.exit_code == 0
+
+    # List values
+    dummy_manager = DummyConfigManager()
+    dummy_manager.set_config_value("SECRET_PROVIDER", "CONJUR_SECRET_PROVIDER")
+    dummy_manager.set_config_value("CONJUR_AUTHN_LOGIN", "user1")
+    monkeypatch.setattr(cli_module, "ConfigManager", lambda: dummy_manager)
+    result = runner.invoke(cli, ['configure', 'list'])
+    assert result.exit_code == 0
+    assert "SECRET_PROVIDER=CONJUR_SECRET_PROVIDER" in result.output
+    assert "CONJUR_AUTHN_LOGIN=user1" in result.output

--- a/tests/integration/test_config_manager_integration.py
+++ b/tests/integration/test_config_manager_integration.py
@@ -1,0 +1,39 @@
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agent_guard_core.config.config_manager import ConfigManager
+
+
+@pytest.fixture
+def temp_config_env(monkeypatch):
+    # Create a temporary directory for config file
+    temp_dir = tempfile.mkdtemp()
+    config_path = Path(temp_dir) / "config.env"
+    monkeypatch.setattr("agent_guard_core.config.config_manager.Path.home",
+                        lambda: Path(temp_dir))
+    yield config_path
+    shutil.rmtree(temp_dir)
+
+
+def test_config_manager_set_and_get(temp_config_env):
+    manager = ConfigManager()
+    manager.set_config_value("INTEGRATION_KEY", "integration_value")
+    assert manager.get_config_value("INTEGRATION_KEY") == "integration_value"
+
+
+def test_config_manager_persistence(temp_config_env):
+    manager = ConfigManager()
+    manager.set_config_value("PERSIST_KEY", "persist_value")
+    # Create a new manager to simulate reload
+    manager2 = ConfigManager()
+    assert manager2.get_config_value("PERSIST_KEY") == "persist_value"
+
+
+def test_config_manager_overwrite(temp_config_env):
+    manager = ConfigManager()
+    manager.set_config_value("OVERWRITE_KEY", "first")
+    manager.set_config_value("OVERWRITE_KEY", "second")
+    assert manager.get_config_value("OVERWRITE_KEY") == "second"

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -1,0 +1,52 @@
+import pytest
+
+from agent_guard_core.config.config_manager import ConfigManager, ConfigurationOptions
+
+
+class DummyFileSecretsProvider:
+
+    def __init__(self, namespace):
+        self._file = namespace
+        self._dict = {}
+
+    def get_secret_dictionary(self):
+        return self._dict
+
+    def store_secret_dictionary(self, d):
+        self._dict = dict(d)
+
+
+@pytest.fixture
+def temp_config(monkeypatch):
+    # Patch FileSecretsProvider in ConfigManager to use DummyFileSecretsProvider
+    from agent_guard_core import config
+    monkeypatch.setattr(config.config_manager, "FileSecretsProvider",
+                        DummyFileSecretsProvider)
+    yield
+
+
+def test_set_and_get_config_value(temp_config):
+    manager = ConfigManager()
+    manager.set_config_value("TEST_KEY", "test_value")
+    assert manager.get_config_value("TEST_KEY") == "test_value"
+
+
+def test_get_config_returns_dict(temp_config):
+    manager = ConfigManager()
+    manager.set_config_value("A", "1")
+    config = manager.get_config()
+    assert isinstance(config, dict)
+    assert config["A"] == "1"
+
+
+def test_overwrite_config_value(temp_config):
+    manager = ConfigManager()
+    manager.set_config_value("B", "first")
+    manager.set_config_value("B", "second")
+    assert manager.get_config_value("B") == "second"
+
+
+def test_enum_keys():
+    keys = ConfigurationOptions.__members__.keys()
+    assert "SECRET_PROVIDER" in keys
+    assert "CONJUR_AUTHN_LOGIN" in keys


### PR DESCRIPTION
* added _authenticat_jwt(), get_secret() and user-defined cred provider options for authn functions

* removed conditional call to external cred provider function in _authenticat_aws()

* use HTTPStatus codes vs. local constants

---------

Co-authored-by: Jody Hunt <Jody.Hunt@NG-JODY-H.local>

### Desired Outcome

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?  Feel free to copy
this information from the connected issue.*

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
