### PR TITLE
add environment_manager import in credentials/_init__.py

### DIFF
--- a/agent_guard_core/credentials/__init__.py
+++ b/agent_guard_core/credentials/__init__.py
@@ -1,3 +1,4 @@
+from .environment_manager import EnvironmentVariablesManager
 from .aws_secrets_manager_provider import AWSSecretsProvider
 from .conjur_secrets_provider import ConjurSecretsProvider
 from .file_secrets_provider import FileSecretsProvider


### PR DESCRIPTION
### Desired Outcome

```from agent_guard_core.credentials import FileSecretsProvider, EnvironmentVariablesManager```

should not generate an import error

### Implemented Changes

added import line in agent_guard_core/credentials/__init__.py
```from .environment_manager import EnvironmentVariablesManager```

#### Changelog

This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

The changes in this PR do not require tests

#### Documentation

This PR does not require updating any documentation

#### Behavior

No behavior was changed with this PR

#### Security

There are no security aspects to these changes
